### PR TITLE
upgrade to cdkv2

### DIFF
--- a/redshift_poc_automation/stacks/sct_stack.py
+++ b/redshift_poc_automation/stacks/sct_stack.py
@@ -1,6 +1,5 @@
 from aws_cdk import aws_iam
 from aws_cdk import aws_ec2
-# from aws_cdk import core
 from aws_cdk import aws_secretsmanager
 import boto3
 import json
@@ -8,12 +7,10 @@ import json
 from aws_cdk import Stack
 from constructs import Construct
 
-# class SctOnPremToRedshiftStack(core.Stack):
 class SctOnPremToRedshiftStack(Stack):
 
     def __init__(
             self,
-            # scope: core.Construct, id: str,
             scope: Construct, id: str,
             other_config: dict,
             vpc,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* "AWS CDK v2 consolidates the stable parts of the AWS Construct Library, including the core library, into a single package, aws-cdk-lib. Developers no longer need to install additional packages for the individual AWS services they use." https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
